### PR TITLE
Fix bug in concentration game

### DIFF
--- a/popgym/envs/concentration.py
+++ b/popgym/envs/concentration.py
@@ -85,6 +85,10 @@ class Concentration(gym.Env):
             # Flip two last flipped-up cards face down again
             self.deck.discard_hands("in_play", "in_play_idx")
             self.hand = []
+        elif self.deck["in_play_idx"][0] in self.deck["face_up_idx"]:
+            # Trying to turn a card that is already face up
+            reward = self.failure_reward_scale
+            self.deck.discard_hands("in_play", "in_play_idx")
 
         self.curr_step += 1
 


### PR DESCRIPTION
Hello,

In concentration the agent can select a card that is already face up. Therefore, once the agent found a matching pair it can play it indefinitely. This pull request add a check for that, if the card is already face up the reward is `failure_reward_scale` is given.

Bellow is a simple way to abuse the lack of check.

Best,
Raphael

```python
def abuse_loop(env):
    obs = env.reset()
    r_c = 0
    obs, r, d, _ = env.step(0)
    r_c += r
    cards = [obs[0]]
    found = False
    i = 0
    while not d and not found:
        i += 1
        obs, r, d, _ = env.step(i)
        r_c += r
        found = obs[i] in cards
        cards.append(obs[i])
    j = cards.index(obs[i])
    if not d and i % 2 != 1:
        obs, r, d, _ = env.step(j)
        r_c += r
    while not d:
        obs, r, d, _ = env.step(i)
        r_c += r
        i, j = j, i
    return r_c
```

