### PR TITLE
Fix noise in noisy stateless cartpole and pendulum

### DIFF
--- a/popgym/envs/noisy_stateless_cartpole.py
+++ b/popgym/envs/noisy_stateless_cartpole.py
@@ -10,7 +10,7 @@ class NoisyStatelessCartPole(StatelessCartPole):
     def __init__(self, *args, **kwargs):
         noise_sigma = kwargs.pop("noise_sigma", 0.1)
         super().__init__(*args, **kwargs)
-        self.noise_sigma = np.full_like(self.observation_space.shape, noise_sigma)
+        self.noise_sigma = np.full(self.observation_space.shape, noise_sigma)
 
     def step(
         self, action: gym.core.ActType

--- a/popgym/envs/noisy_stateless_pendulum.py
+++ b/popgym/envs/noisy_stateless_pendulum.py
@@ -10,7 +10,7 @@ class NoisyStatelessPendulum(StatelessPendulum):
     def __init__(self, *args, **kwargs):
         noise_sigma = kwargs.pop("noise_sigma", 0.1)
         super().__init__(*args, **kwargs)
-        self.noise_sigma = np.full_like(self.observation_space.shape, noise_sigma)
+        self.noise_sigma = np.full(self.observation_space.shape, noise_sigma)
 
     def step(
         self, action: gym.core.ActType


### PR DESCRIPTION
Hello,
There is a bug in noisy stateless cartpole and pendulum that sets the noise to 0 no matter the input parameter.
```python
print(np.full_like(self.observation_space.shape, noise_sigma))
>>> array([0])
```
Best,
Raphael