### PR TITLE
Split navigation envs into extras

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,6 +40,31 @@ jobs:
         pytest tests/test* --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
     - name: Upload test coverage
       uses: codecov/codecov-action@v2
-        #- name: Upload codecov results
-        #run: |
-        #curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov 
+
+  build_mazelib:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pytest-cov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install -e ".[navigation]"
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --ignore=E203
+    - name: Test with pytest
+      run: |
+        pytest tests/test* --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+    - name: Upload test coverage
+      uses: codecov/codecov-action@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ POPGym is designed to benchmark memory in deep reinforcement learning. It contai
 ## Quickstart Install
 
 ```python
-pip install popgym # environments only
+pip install popgym # base environments only, only requires numpy and gymnasium
+pip install "popgym[navigation]" # also include navigation environments, which require mazelib
 pip install "popgym[baselines]" # environments and memory baselines
 ```
 

--- a/popgym/envs/__init__.py
+++ b/popgym/envs/__init__.py
@@ -2,6 +2,7 @@
 """
 
 import inspect
+from importlib import find_loader
 from typing import Any, Dict
 
 import gymnasium as gym
@@ -35,18 +36,6 @@ from popgym.envs.higher_lower import (
     HigherLowerEasy,
     HigherLowerHard,
     HigherLowerMedium,
-)
-from popgym.envs.labyrinth_escape import (
-    LabyrinthEscape,
-    LabyrinthEscapeEasy,
-    LabyrinthEscapeHard,
-    LabyrinthEscapeMedium,
-)
-from popgym.envs.labyrinth_explore import (
-    LabyrinthExplore,
-    LabyrinthExploreEasy,
-    LabyrinthExploreHard,
-    LabyrinthExploreMedium,
 )
 from popgym.envs.minesweeper import (
     MineSweeper,
@@ -244,25 +233,51 @@ ALL_GAME = {**GAME_EASY, **GAME_MEDIUM, **GAME_HARD}
 #
 # Navigation envs
 #
-NAVIGATION: Dict[gym.Env, Dict[str, Any]] = {
-    LabyrinthExplore: {"id": "popgym-LabyrinthExplore-v0"},
-    LabyrinthEscape: {"id": "popgym-LabyrinthEscape-v0"},
-}
+def has_mazelib():  # noqa: E302
+    """Check if mazelib is installed"""
+    return find_loader("mazelib") is not None
 
-NAVIGATION_EASY: Dict[gym.Env, Dict[str, Any]] = {
-    LabyrinthExploreEasy: {"id": "popgym-LabyrinthExploreEasy-v0"},
-    LabyrinthEscapeEasy: {"id": "popgym-LabyrinthEscapeEasy-v0"},
-}
 
-NAVIGATION_MEDIUM: Dict[gym.Env, Dict[str, Any]] = {
-    LabyrinthExploreMedium: {"id": "popgym-LabyrinthExploreMedium-v0"},
-    LabyrinthEscapeMedium: {"id": "popgym-LabyrinthEscapeMedium-v0"},
-}
+if has_mazelib():
+    # mazelib can somtimes be a headache to install
+    # mazes are also a poor test of memory
+    from popgym.envs.labyrinth_escape import (
+        LabyrinthEscape,
+        LabyrinthEscapeEasy,
+        LabyrinthEscapeHard,
+        LabyrinthEscapeMedium,
+    )
+    from popgym.envs.labyrinth_explore import (
+        LabyrinthExplore,
+        LabyrinthExploreEasy,
+        LabyrinthExploreHard,
+        LabyrinthExploreMedium,
+    )
 
-NAVIGATION_HARD: Dict[gym.Env, Dict[str, Any]] = {
-    LabyrinthExploreHard: {"id": "popgym-LabyrinthExploreHard-v0"},
-    LabyrinthEscapeHard: {"id": "popgym-LabyrinthEscapeHard-v0"},
-}
+    NAVIGATION: Dict[gym.Env, Dict[str, Any]] = {
+        LabyrinthExplore: {"id": "popgym-LabyrinthExplore-v0"},
+        LabyrinthEscape: {"id": "popgym-LabyrinthEscape-v0"},
+    }
+
+    NAVIGATION_EASY: Dict[gym.Env, Dict[str, Any]] = {
+        LabyrinthExploreEasy: {"id": "popgym-LabyrinthExploreEasy-v0"},
+        LabyrinthEscapeEasy: {"id": "popgym-LabyrinthEscapeEasy-v0"},
+    }
+
+    NAVIGATION_MEDIUM: Dict[gym.Env, Dict[str, Any]] = {
+        LabyrinthExploreMedium: {"id": "popgym-LabyrinthExploreMedium-v0"},
+        LabyrinthEscapeMedium: {"id": "popgym-LabyrinthEscapeMedium-v0"},
+    }
+
+    NAVIGATION_HARD: Dict[gym.Env, Dict[str, Any]] = {
+        LabyrinthExploreHard: {"id": "popgym-LabyrinthExploreHard-v0"},
+        LabyrinthEscapeHard: {"id": "popgym-LabyrinthEscapeHard-v0"},
+    }
+else:
+    NAVIGATION = {}
+    NAVIGATION_EASY = {}
+    NAVIGATION_MEDIUM = {}
+    NAVIGATION_HARD = {}
 
 ALL_NAVIGATION = {
     **NAVIGATION_EASY,

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,10 @@ packages = find:
 install_requires = 
     numpy
     gymnasium
-    mazelib
 
 [options.extras_require]
+navigation =
+    mazelib
 baselines = 
     torch
     opt_einsum

--- a/tests/test_labyrinth_escape.py
+++ b/tests/test_labyrinth_escape.py
@@ -1,45 +1,47 @@
 import unittest
 
-from popgym.envs.labyrinth_escape import LabyrinthEscape
+from popgym.envs import has_mazelib
 
+if has_mazelib():
+    from popgym.envs.labyrinth_escape import LabyrinthEscape
 
-class TestLabyrinthEscape(unittest.TestCase):
-    def test_step(self):
-        e = LabyrinthEscape()
-        e.reset()
-        for i in range(1000):
-            _, _, terminated, truncated, _ = e.step(e.action_space.sample())
-            if terminated or truncated:
+    class TestLabyrinthEscape(unittest.TestCase):
+        def test_step(self):
+            e = LabyrinthEscape()
+            e.reset()
+            for i in range(1000):
+                _, _, terminated, truncated, _ = e.step(e.action_space.sample())
+                if terminated or truncated:
+                    e.reset()
+
+        def test_tostring(self):
+            e = LabyrinthEscape((6, 6))
+            e.reset()
+            e.tostring()
+
+        def test_goal(self):
+            e = LabyrinthEscape((6, 6))
+            terminated = truncated = False
+            e.reset()
+            for i in range(5):
+                while not (terminated or truncated):
+                    _, _, terminated, truncated, _ = e.step(e.action_space.sample())
+                self.assertTrue(e.curr_step < e.max_episode_length)
                 e.reset()
 
-    def test_tostring(self):
-        e = LabyrinthEscape((6, 6))
-        e.reset()
-        e.tostring()
+        def test_known(self):
+            e = LabyrinthEscape((8, 8))
+            e.reset(seed=1)
+            left, right, _, down = 0, 1, 2, 3
+            actions = [down] * 5 + [left] * 2 + [down] * 2 + [right] * 6 + [down] * 1
+            done = False
+            cum_rew = 0
+            for action in actions:
+                self.assertFalse(done)
+                obs, reward, terminated, truncated, info = e.step(action)
+                cum_rew += reward
 
-    def test_goal(self):
-        e = LabyrinthEscape((6, 6))
-        terminated = truncated = False
-        e.reset()
-        for i in range(5):
-            while not (terminated or truncated):
-                _, _, terminated, truncated, _ = e.step(e.action_space.sample())
-            self.assertTrue(e.curr_step < e.max_episode_length)
-            e.reset()
-
-    def test_known(self):
-        e = LabyrinthEscape((8, 8))
-        e.reset(seed=1)
-        left, right, _, down = 0, 1, 2, 3
-        actions = [down] * 5 + [left] * 2 + [down] * 2 + [right] * 6 + [down] * 1
-        done = False
-        cum_rew = 0
-        for action in actions:
-            self.assertFalse(done)
-            obs, reward, terminated, truncated, info = e.step(action)
-            cum_rew += reward
-
-        self.assertTrue(terminated)
-        self.assertFalse(truncated)
-        expected = 1.0 + len(actions) * e.neg_reward_scale
-        self.assertAlmostEqual(cum_rew, expected)
+            self.assertTrue(terminated)
+            self.assertFalse(truncated)
+            expected = 1.0 + len(actions) * e.neg_reward_scale
+            self.assertAlmostEqual(cum_rew, expected)

--- a/tests/test_labyrinth_explore.py
+++ b/tests/test_labyrinth_explore.py
@@ -2,57 +2,59 @@ import unittest
 
 import numpy as np
 
-from popgym.envs.labyrinth_explore import LabyrinthExplore
+from popgym.envs import has_mazelib
 
+if has_mazelib():
+    from popgym.envs.labyrinth_explore import LabyrinthExplore
 
-class TestLabyrinthExplore(unittest.TestCase):
-    def test_step(self):
-        e = LabyrinthExplore()
-        obs, _ = e.reset()
-        self.assertEqual(obs.dtype, np.int32)
-        terminated = truncated = False
-        for i in range(1000):
-            obs, _, terminated, truncated, _ = e.step(e.action_space.sample())
+    class TestLabyrinthExplore(unittest.TestCase):
+        def test_step(self):
+            e = LabyrinthExplore()
+            obs, _ = e.reset()
             self.assertEqual(obs.dtype, np.int32)
-            if terminated or truncated:
-                obs = e.reset()
+            terminated = truncated = False
+            for i in range(1000):
+                obs, _, terminated, truncated, _ = e.step(e.action_space.sample())
                 self.assertEqual(obs.dtype, np.int32)
+                if terminated or truncated:
+                    obs = e.reset()
+                    self.assertEqual(obs.dtype, np.int32)
 
-    def test_noclip(self):
-        e = LabyrinthExplore()
-        terminated = truncated = False
-        e.reset()
-        for i in range(5):
-            while not (terminated or truncated):
-                _, _, terminated, truncated, _ = e.step(e.action_space.sample())
-
-            visit_mask = e.explored == 1
-            obstacle_mask = e.maze.grid == 1
-            self.assertFalse(np.any(visit_mask * obstacle_mask == 1))
+        def test_noclip(self):
+            e = LabyrinthExplore()
+            terminated = truncated = False
             e.reset()
+            for i in range(5):
+                while not (terminated or truncated):
+                    _, _, terminated, truncated, _ = e.step(e.action_space.sample())
 
-    def test_known(self):
-        e = LabyrinthExplore((6, 6))
-        e.reset(seed=0)
-        left, right, up, down = 0, 1, 2, 3
-        actions = (
-            [left] * 5
-            + [up] * 2
-            + [right] * 2
-            + [left] * 2
-            + [down] * 2
-            + [right] * 4
-            + [up] * 4
-            + [left] * 4
-        )
-        terminated = truncated = False
-        cum_rew = 0
-        for action in actions:
-            self.assertFalse(terminated or truncated)
-            obs, reward, terminated, truncated, info = e.step(action)
-            cum_rew += reward
+                visit_mask = e.explored == 1
+                obstacle_mask = e.maze.grid == 1
+                self.assertFalse(np.any(visit_mask * obstacle_mask == 1))
+                e.reset()
 
-        self.assertTrue(terminated)
-        self.assertFalse(truncated)
-        expected = 1.0 + 8 * e.neg_reward_scale
-        self.assertAlmostEqual(cum_rew, expected)
+        def test_known(self):
+            e = LabyrinthExplore((6, 6))
+            e.reset(seed=0)
+            left, right, up, down = 0, 1, 2, 3
+            actions = (
+                [left] * 5
+                + [up] * 2
+                + [right] * 2
+                + [left] * 2
+                + [down] * 2
+                + [right] * 4
+                + [up] * 4
+                + [left] * 4
+            )
+            terminated = truncated = False
+            cum_rew = 0
+            for action in actions:
+                self.assertFalse(terminated or truncated)
+                obs, reward, terminated, truncated, info = e.step(action)
+                cum_rew += reward
+
+            self.assertTrue(terminated)
+            self.assertFalse(truncated)
+            expected = 1.0 + 8 * e.neg_reward_scale
+            self.assertAlmostEqual(cum_rew, expected)


### PR DESCRIPTION
This splits navigation envs into an extra install: `pip install 'popgym[navigation]'` so we don't need to rely on mazelib for the core envs.