### PR TITLE
Fix flatten wrapper

### DIFF
--- a/popgym/wrappers/flatten.py
+++ b/popgym/wrappers/flatten.py
@@ -1,10 +1,12 @@
-from gettext import npgettext
 from typing import Tuple
+
 import gymnasium as gym
+import numpy as np
 from gymnasium.core import ActType, ObsType
+
 from popgym.core.env import POPGymEnv
 from popgym.core.wrapper import POPGymWrapper
-import numpy as np
+
 
 class Flatten(POPGymWrapper):
     """
@@ -12,23 +14,35 @@ class Flatten(POPGymWrapper):
     to make them compatible with neural networks.
     """
 
-    def __init__(self, env: POPGymEnv, flatten_action: bool=True, flatten_observation: bool=True):
+    def __init__(
+        self,
+        env: POPGymEnv,
+        flatten_action: bool = True,
+        flatten_observation: bool = True,
+    ):
         super().__init__(env)
         self.need_flatten_action = False
         self.need_flatten_obs = False
         if flatten_action:
             # Check that spaces are either all continuous or all discrete
             self.continuous(self.env.action_space)
-            self.need_flatten_action = isinstance(self.env.action_space, gym.spaces.Tuple) or isinstance(self.env.action_space, gym.spaces.Dict)
+            self.need_flatten_action = isinstance(
+                self.env.action_space, gym.spaces.Tuple
+            ) or isinstance(self.env.action_space, gym.spaces.Dict)
             if self.need_flatten_action:
-                self.action_space = gym.spaces.utils.flatten_space(self.env.action_space)
+                self.action_space = gym.spaces.utils.flatten_space(
+                    self.env.action_space
+                )
         if flatten_observation:
             self.continuous(self.env.observation_space)
-            self.need_flatten_obs = isinstance(self.env.action_space, gym.spaces.Tuple) or isinstance(self.env.action_space, gym.spaces.Dict)
+            self.need_flatten_obs = isinstance(
+                self.env.observation_space, gym.spaces.Tuple
+            ) or isinstance(self.env.observation_space, gym.spaces.Dict)
             if self.need_flatten_obs:
-                self.observation_space = gym.spaces.utils.flatten_space(self.env.observation_space)
+                self.observation_space = gym.spaces.utils.flatten_space(
+                    self.env.observation_space
+                )
 
-    
     def step(self, action: ActType) -> Tuple[ObsType, float, bool, bool, dict]:
         if self.need_flatten_action:
             flat_action = gym.spaces.utils.unflatten(self.env.action_space, action)
@@ -53,7 +67,10 @@ class Flatten(POPGymWrapper):
                 return False
             else:
                 return True
-        elif isinstance(space, (gym.spaces.Discrete, gym.spaces.MultiDiscrete, gym.spaces.MultiBinary)):
+        elif isinstance(
+            space,
+            (gym.spaces.Discrete, gym.spaces.MultiDiscrete, gym.spaces.MultiBinary),
+        ):
             return False
         elif isinstance(space, gym.spaces.Tuple):
             res = [self.continuous(s) for s in space.spaces]


### PR DESCRIPTION
This should fix one of the issues from #19, namely that the `Flatten` wrapper incorrectly detects whether the observation space must be flattened.