### PR TITLE
Enable flattening mixed discrete/continuous observation spaces

### DIFF
--- a/popgym/wrappers/flatten.py
+++ b/popgym/wrappers/flatten.py
@@ -34,7 +34,6 @@ class Flatten(POPGymWrapper):
                     self.env.action_space
                 )
         if flatten_observation:
-            self.continuous(self.env.observation_space)
             self.need_flatten_obs = isinstance(
                 self.env.observation_space, gym.spaces.Tuple
             ) or isinstance(self.env.observation_space, gym.spaces.Dict)


### PR DESCRIPTION
This enables the use of the `Flatten` wrapper with mixed discrete and continuous observation spaces.