### PR TITLE
[Breaking] Differentiate between velocity-cartpole and position-cartpole

### DIFF
--- a/examples/play_cartpole.py
+++ b/examples/play_cartpole.py
@@ -1,7 +1,7 @@
-from popgym.envs.stateless_cartpole import StatelessCartPole
+from popgym.envs.stateless_cartpole import PositionOnlyCartPole
 
 if __name__ == "__main__":
-    game = StatelessCartPole()
+    game = PositionOnlyCartPole()
     done = False
     obs, info = game.reset(return_info=True)
     reward = -float("inf")

--- a/examples/play_minesweeper.py
+++ b/examples/play_minesweeper.py
@@ -1,15 +1,18 @@
-from popgym.envs.minesweeper import MineSweeperHard
+from popgym.envs.minesweeper import MineSweeperEasy
 
 if __name__ == "__main__":
-    game = MineSweeperHard()
+    game = MineSweeperEasy()
     done = False
-    obs, info = game.reset(return_info=True)
+    obs, info = game.reset()
     reward = -float("inf")
     game.render()
+    done = False
 
     while not done:
         action = input("input index:").split(",")
         action_int = (int(action[0]), int(action[1]))
-        obs, reward, done, info = game.step(action_int)
-        game.render()
+        obs, reward, truncated, terminated, info = game.step(action_int)
+        done = truncated or terminated
+        print(obs)
+        # game.render()
         print("reward:", reward)

--- a/examples/play_pendulum.py
+++ b/examples/play_pendulum.py
@@ -1,7 +1,7 @@
-from popgym.envs.stateless_pendulum import StatelessPendulum
+from popgym.envs.stateless_pendulum import PositionOnlyPendulum
 
 if __name__ == "__main__":
-    game = StatelessPendulum()
+    game = PositionOnlyPendulum()
     done = False
     obs, info = game.reset(return_info=True)
     reward = -float("inf")

--- a/popgym/envs/__init__.py
+++ b/popgym/envs/__init__.py
@@ -49,17 +49,29 @@ from popgym.envs.multiarmed_bandit import (
     MultiarmedBanditHard,
     MultiarmedBanditMedium,
 )
-from popgym.envs.noisy_stateless_cartpole import (
-    NoisyStatelessCartPole,
-    NoisyStatelessCartPoleEasy,
-    NoisyStatelessCartPoleHard,
-    NoisyStatelessCartPoleMedium,
+from popgym.envs.noisy_position_only_cartpole import (
+    NoisyPositionOnlyCartPole,
+    NoisyPositionOnlyCartPoleEasy,
+    NoisyPositionOnlyCartPoleHard,
+    NoisyPositionOnlyCartPoleMedium,
 )
 from popgym.envs.noisy_stateless_pendulum import (
-    NoisyStatelessPendulum,
-    NoisyStatelessPendulumEasy,
-    NoisyStatelessPendulumHard,
-    NoisyStatelessPendulumMedium,
+    NoisyPositionOnlyPendulum,
+    NoisyPositionOnlyPendulumEasy,
+    NoisyPositionOnlyPendulumHard,
+    NoisyPositionOnlyPendulumMedium,
+)
+from popgym.envs.position_only_cartpole import (
+    PositionOnlyCartPole,
+    PositionOnlyCartPoleEasy,
+    PositionOnlyCartPoleHard,
+    PositionOnlyCartPoleMedium,
+)
+from popgym.envs.position_only_pendulum import (
+    PositionOnlyPendulum,
+    PositionOnlyPendulumEasy,
+    PositionOnlyPendulumHard,
+    PositionOnlyPendulumMedium,
 )
 from popgym.envs.repeat_first import (
     RepeatFirst,
@@ -73,17 +85,11 @@ from popgym.envs.repeat_previous import (
     RepeatPreviousHard,
     RepeatPreviousMedium,
 )
-from popgym.envs.stateless_cartpole import (
-    StatelessCartPole,
-    StatelessCartPoleEasy,
-    StatelessCartPoleHard,
-    StatelessCartPoleMedium,
-)
-from popgym.envs.stateless_pendulum import (
-    StatelessPendulum,
-    StatelessPendulumEasy,
-    StatelessPendulumHard,
-    StatelessPendulumMedium,
+from popgym.envs.velocity_only_cartpole import (
+    VelocityOnlyCartPole,
+    VelocityOnlyCartPoleEasy,
+    VelocityOnlyCartPoleHard,
+    VelocityOnlyCartPoleMedium,
 )
 
 #
@@ -123,34 +129,46 @@ ALL_DIAGNOSTIC = {**DIAGNOSTIC_EASY, **DIAGNOSTIC_MEDIUM, **DIAGNOSTIC_HARD}
 # Control envs
 #
 CONTROL: Dict[gym.Env, Dict[str, Any]] = {
-    StatelessCartPole: {"id": "popgym-StatelessCartPole-v0"},
-    StatelessPendulum: {
-        "id": "popgym-StatelessPendulum-v0",
+    PositionOnlyCartPole: {"id": "popgym-PositionOnlyCartPole-v0"},
+    PositionOnlyPendulum: {
+        "id": "popgym-PositionOnlyPendulum-v0",
     },
+    VelocityOnlyCartPole: {
+        "id": "popgym-VelocityOnlyCartpole-v0",
+    }
     # BipedalWalker: {"id": "popgym-BipedalWalker-v0"},
 }
 
 CONTROL_EASY: Dict[gym.Env, Dict[str, Any]] = {
-    StatelessCartPoleEasy: {"id": "popgym-StatelessCartPoleEasy-v0"},
-    StatelessPendulumEasy: {
-        "id": "popgym-StatelessPendulumEasy-v0",
+    PositionOnlyCartPoleEasy: {"id": "popgym-PositionOnlyCartPoleEasy-v0"},
+    PositionOnlyPendulumEasy: {
+        "id": "popgym-PositionOnlyPendulumEasy-v0",
     },
+    VelocityOnlyCartPoleEasy: {
+        "id": "popgym-VelocityOnlyCartpoleEasy-v0",
+    }
     # BipedalWalkerEasy: {"id": "popgym-BipedalWalkerEasy-v0"},
 }
 
 CONTROL_MEDIUM: Dict[gym.Env, Dict[str, Any]] = {
-    StatelessCartPoleMedium: {"id": "popgym-StatelessCartPoleMedium-v0"},
-    StatelessPendulumMedium: {
-        "id": "popgym-StatelessPendulumMedium-v0",
+    PositionOnlyCartPoleMedium: {"id": "popgym-PositionOnlyCartPoleMedium-v0"},
+    PositionOnlyPendulumMedium: {
+        "id": "popgym-PositionOnlyPendulumMedium-v0",
     },
+    VelocityOnlyCartPoleMedium: {
+        "id": "popgym-VelocityOnlyCartpoleMedium-v0",
+    }
     # BipedalWalkerMedium: {"id": "popgym-BipedalWalkerMedium-v0"},
 }
 
 CONTROL_HARD: Dict[gym.Env, Dict[str, Any]] = {
-    StatelessCartPoleHard: {"id": "popgym-StatelessCartPoleHard-v0"},
-    StatelessPendulumHard: {
-        "id": "popgym-StatelessPendulumHard-v0",
+    PositionOnlyCartPoleHard: {"id": "popgym-PositionOnlyCartPoleHard-v0"},
+    PositionOnlyPendulumHard: {
+        "id": "popgym-PositionOnlyPendulumHard-v0",
     },
+    VelocityOnlyCartPoleHard: {
+        "id": "popgym-VelocityOnlyCartpoleHard-v0",
+    }
     # BipedalWalkerHard: {"id": "popgym-BipedalWalkerHard-v0"},
 }
 
@@ -160,36 +178,38 @@ ALL_CONTROL = {**CONTROL_EASY, **CONTROL_MEDIUM, **CONTROL_HARD}
 # Noisy envs
 #
 NOISY: Dict[gym.Env, Dict[str, Any]] = {
-    NoisyStatelessCartPole: {"id": "popgym-NoisyStatelessCartPole-v0"},
-    NoisyStatelessPendulum: {
-        "id": "popgym-NoisyStatelessPendulum-v0",
+    NoisyPositionOnlyCartPole: {"id": "popgym-NoisyPositionOnlyCartPole-v0"},
+    NoisyPositionOnlyPendulum: {
+        "id": "popgym-NoisyPositionOnlyPendulum-v0",
     },
     MultiarmedBandit: {"id": "popgym-MultiarmedBandit-v0"},
     # NonstationaryBandit: {"id": "popgym-NonstationaryBandit-v0"},
 }
 
 NOISY_EASY: Dict[gym.Env, Dict[str, Any]] = {
-    NoisyStatelessCartPoleEasy: {"id": "popgym-NoisyStatelessCartPoleEasy-v0"},
-    NoisyStatelessPendulumEasy: {
-        "id": "popgym-NoisyStatelessPendulumEasy-v0",
+    NoisyPositionOnlyCartPoleEasy: {"id": "popgym-NoisyPositionOnlyCartPoleEasy-v0"},
+    NoisyPositionOnlyPendulumEasy: {
+        "id": "popgym-NoisyPositionOnlyPendulumEasy-v0",
     },
     MultiarmedBanditEasy: {"id": "popgym-MultiarmedBanditEasy-v0"},
     # NonstationaryBanditEasy: {"id": "popgym-NonstationaryBanditEasy-v0"},
 }
 
 NOISY_MEDIUM: Dict[gym.Env, Dict[str, Any]] = {
-    NoisyStatelessCartPoleMedium: {"id": "popgym-NoisyStatelessCartPoleMedium-v0"},
-    NoisyStatelessPendulumMedium: {
-        "id": "popgym-NoisyStatelessPendulumMedium-v0",
+    NoisyPositionOnlyCartPoleMedium: {
+        "id": "popgym-NoisyPositionOnlyCartPoleMedium-v0"
+    },
+    NoisyPositionOnlyPendulumMedium: {
+        "id": "popgym-NoisyPositionOnlyPendulumMedium-v0",
     },
     MultiarmedBanditMedium: {"id": "popgym-MultiarmedBanditMedium-v0"},
     # NonstationaryBanditMedium: {"id": "popgym-NonstationaryBanditMedium-v0"},
 }
 
 NOISY_HARD: Dict[gym.Env, Dict[str, Any]] = {
-    NoisyStatelessCartPoleHard: {"id": "popgym-NoisyStatelessCartPoleHard-v0"},
-    NoisyStatelessPendulumHard: {
-        "id": "popgym-NoisyStatelessPendulumHard-v0",
+    NoisyPositionOnlyCartPoleHard: {"id": "popgym-NoisyPositionOnlyCartPoleHard-v0"},
+    NoisyPositionOnlyPendulumHard: {
+        "id": "popgym-NoisyPositionOnlyPendulumHard-v0",
     },
     MultiarmedBanditHard: {"id": "popgym-MultiarmedBanditHard-v0"},
     # NonstationaryBanditHard: {"id": "popgym-NonstationaryBanditHard-v0"},

--- a/popgym/envs/noisy_position_only_cartpole.py
+++ b/popgym/envs/noisy_position_only_cartpole.py
@@ -4,10 +4,10 @@ import gymnasium as gym
 import numpy as np
 from gymnasium.core import ActType, ObsType
 
-from popgym.envs.stateless_cartpole import StatelessCartPole
+from popgym.envs.position_only_cartpole import PositionOnlyCartPole
 
 
-class NoisyStatelessCartPole(StatelessCartPole):
+class NoisyPositionOnlyCartPole(PositionOnlyCartPole):
     def __init__(self, *args, **kwargs):
         noise_sigma = kwargs.pop("noise_sigma", 0.1)
         super().__init__(*args, **kwargs)
@@ -33,16 +33,16 @@ class NoisyStatelessCartPole(StatelessCartPole):
         return init_obs, info
 
 
-class NoisyStatelessCartPoleEasy(NoisyStatelessCartPole):
+class NoisyPositionOnlyCartPoleEasy(NoisyPositionOnlyCartPole):
     def __init__(self):
         super().__init__(noise_sigma=0.1)
 
 
-class NoisyStatelessCartPoleMedium(NoisyStatelessCartPole):
+class NoisyPositionOnlyCartPoleMedium(NoisyPositionOnlyCartPole):
     def __init__(self):
         super().__init__(noise_sigma=0.2)
 
 
-class NoisyStatelessCartPoleHard(NoisyStatelessCartPole):
+class NoisyPositionOnlyCartPoleHard(NoisyPositionOnlyCartPole):
     def __init__(self):
         super().__init__(noise_sigma=0.3)

--- a/popgym/envs/noisy_stateless_pendulum.py
+++ b/popgym/envs/noisy_stateless_pendulum.py
@@ -4,10 +4,10 @@ import gymnasium as gym
 import numpy as np
 from gymnasium.core import ActType, ObsType
 
-from popgym.envs.stateless_pendulum import StatelessPendulum
+from popgym.envs.position_only_pendulum import PositionOnlyPendulum
 
 
-class NoisyStatelessPendulum(StatelessPendulum):
+class NoisyPositionOnlyPendulum(PositionOnlyPendulum):
     def __init__(self, *args, **kwargs):
         noise_sigma = kwargs.pop("noise_sigma", 0.1)
         super().__init__(*args, **kwargs)
@@ -32,16 +32,16 @@ class NoisyStatelessPendulum(StatelessPendulum):
         return init_obs, info
 
 
-class NoisyStatelessPendulumEasy(NoisyStatelessPendulum):
+class NoisyPositionOnlyPendulumEasy(NoisyPositionOnlyPendulum):
     def __init__(self):
         super().__init__(noise_sigma=0.1)
 
 
-class NoisyStatelessPendulumMedium(NoisyStatelessPendulum):
+class NoisyPositionOnlyPendulumMedium(NoisyPositionOnlyPendulum):
     def __init__(self):
         super().__init__(noise_sigma=0.2)
 
 
-class NoisyStatelessPendulumHard(NoisyStatelessPendulum):
+class NoisyPositionOnlyPendulumHard(NoisyPositionOnlyPendulum):
     def __init__(self):
         super().__init__(noise_sigma=0.3)

--- a/popgym/envs/position_only_cartpole.py
+++ b/popgym/envs/position_only_cartpole.py
@@ -13,7 +13,7 @@ from gymnasium.spaces import Box
 from popgym.core.env import POPGymEnv
 
 
-class StatelessCartPole(CartPoleEnv, POPGymEnv):
+class PositionOnlyCartPole(CartPoleEnv, POPGymEnv):
     """Partially observable variant of the CartPole gym environment.
 
     https://github.com/openai/gym/blob/master/gym/envs/classic_control/
@@ -73,15 +73,15 @@ class StatelessCartPole(CartPoleEnv, POPGymEnv):
         return init_obs, info
 
 
-class StatelessCartPoleEasy(StatelessCartPole):
+class PositionOnlyCartPoleEasy(PositionOnlyCartPole):
     pass
 
 
-class StatelessCartPoleMedium(StatelessCartPole):
+class PositionOnlyCartPoleMedium(PositionOnlyCartPole):
     def __init__(self, *args, **kwargs):
         super().__init__(max_episode_length=400)
 
 
-class StatelessCartPoleHard(StatelessCartPole):
+class PositionOnlyCartPoleHard(PositionOnlyCartPole):
     def __init__(self, *args, **kwargs):
         super().__init__(max_episode_length=600)

--- a/popgym/envs/position_only_pendulum.py
+++ b/popgym/envs/position_only_pendulum.py
@@ -12,7 +12,7 @@ from gymnasium.spaces import Box
 from popgym.core.env import POPGymEnv
 
 
-class StatelessPendulum(PendulumEnv, POPGymEnv):
+class PositionOnlyPendulum(PendulumEnv, POPGymEnv):
     """Partially observable variant of the Pendulum gym environment.
 
     https://github.com/openai/gym/blob/master/gym/envs/classic_control/
@@ -64,15 +64,15 @@ class StatelessPendulum(PendulumEnv, POPGymEnv):
         return init_obs[:-1], info
 
 
-class StatelessPendulumEasy(StatelessPendulum):
+class PositionOnlyPendulumEasy(PositionOnlyPendulum):
     pass
 
 
-class StatelessPendulumMedium(StatelessPendulum):
+class PositionOnlyPendulumMedium(PositionOnlyPendulum):
     def __init__(self):
         super().__init__(max_episode_length=150)
 
 
-class StatelessPendulumHard(StatelessPendulum):
+class PositionOnlyPendulumHard(PositionOnlyPendulum):
     def __init__(self):
         super().__init__(max_episode_length=100)

--- a/popgym/envs/velocity_only_cartpole.py
+++ b/popgym/envs/velocity_only_cartpole.py
@@ -1,0 +1,87 @@
+# Inspired by ray rllib at
+# https://github.com/ray-project/ray/blob/master/rllib/examples/env/stateless_cartpole.py
+
+import math
+from typing import Optional, Tuple
+
+import gymnasium as gym
+import numpy as np
+from gymnasium.core import ActType, ObsType
+from gymnasium.envs.classic_control import CartPoleEnv
+from gymnasium.spaces import Box
+
+from popgym.core.env import POPGymEnv
+
+
+class VelocityOnlyCartPole(CartPoleEnv, POPGymEnv):
+    """Partially observable variant of the CartPole gym environment.
+
+    https://github.com/openai/gym/blob/master/gym/envs/classic_control/
+    cartpole.py
+    We delete the x- and angular position components of the state, so that it
+    can only be solved by a memory enhanced model (policy).
+
+    Args:
+        max_episode_length: Exactly what it sounds like
+    Returns:
+        A gym environment
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.max_episode_length = kwargs.pop("max_episode_length", 200)
+        super().__init__(*args, **kwargs)
+
+        # Fix our observation-space (remove 2 velocity components).
+        high = np.array(
+            [
+                np.inf,
+                np.inf,
+            ],
+            dtype=np.float32,
+        )
+        self.state_space = self.observation_space
+        self.observation_space = Box(low=-high, high=high, dtype=np.float32)
+
+    def get_state(self):
+        state = np.array(self.state, dtype=np.float32)
+        return state
+
+    def reward_transform(self, reward):
+        if math.isclose(reward, 0):
+            transformed = -1.0
+        else:
+            transformed = 1.0 / self.max_episode_length
+        return transformed
+
+    def step(self, action: ActType) -> Tuple[ObsType, float, bool, bool, dict]:
+        next_obs, reward, terminated, truncated, info = super().step(action)
+        self.num_steps += 1
+        if self.num_steps >= self.max_episode_length:
+            # Agent beat episode
+            truncated = True
+        reward = self.reward_transform(reward)
+        # next_obs is [x-pos, x-veloc, angle, angle-veloc]
+        next_obs = np.array([next_obs[1], next_obs[3]])
+        return next_obs, reward, terminated, truncated, info
+
+    def reset(
+        self, *, seed: Optional[int] = None, options: Optional[dict] = None
+    ) -> Tuple[gym.core.ObsType, dict]:
+        self.num_steps = 0
+        init_obs, info = super().reset(seed=seed, options=options)
+        init_obs = np.array([init_obs[0], init_obs[2]])
+        return init_obs, info
+
+
+class VelocityOnlyCartPoleEasy(VelocityOnlyCartPole):
+    pass
+
+
+class VelocityOnlyCartPoleMedium(VelocityOnlyCartPole):
+    def __init__(self, *args, **kwargs):
+        super().__init__(max_episode_length=400)
+
+
+class VelocityOnlyCartPoleHard(VelocityOnlyCartPole):
+    def __init__(self, *args, **kwargs):
+        super().__init__(max_episode_length=600)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,10 @@ description = A collection of partially-observable procedural gym environments
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Steven Morad
-version = 1.0.2
+version = 1.0.3
 license = MIT
 readme = README.md
-requires-python = >=3.7 <=3.10 # Remove 3.10 limit when mazelib fixes its build process
+requires_python = >=3.7 <=3.10 # Remove 3.10 limit when mazelib fixes its build process
 keywords = gym, gymnasium, pomdp, partially observable, reinforcement learning, rl
 
 [options]

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -111,7 +111,7 @@ def test_flatten_step(env):
 
 @pytest.mark.parametrize("env", envs.ALL.keys())
 def test_discrete_action(env):
-    if issubclass(env, (envs.StatelessPendulum, envs.NoisyStatelessPendulum)):
+    if issubclass(env, (envs.PositionOnlyPendulum, envs.NoisyPositionOnlyPendulum)):
         pytest.skip("StatelessPendulum does not support discrete action space")
     wrapped = DiscreteAction(Flatten(env()))
     _, _ = wrapped.reset()


### PR DESCRIPTION
`StatelessCartPole` was a bad env name because it was not clear whether the velocity or position was masked. This PR renames `StatelessCartPole` to `PositionOnlyCartPole` and renames `StatelessPendulum` to `PositionOnlyPendulum`. It also adds the `VelocityOnlyCartPole` env.