### PR TITLE
Remove call to deprecated importlib find_loader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         name: isort (python)
         args: ["--profile", "black"]
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ pip install "popgym[navigation]"
 pip install "popgym[baselines]" 
 ```
 
+## Quickstart Usage
+```python
+import popgym
+from popgym.wrappers import PreviousAction, Antialias, Flatten, DiscreteAction
+env = popgym.envs.position_only_cartpole.PositionOnlyCartPoleEasy()
+print(env.reset(seed=0))
+wrapped = DiscreteAction(Flatten(PreviousAction(env))) # Append prev action to obs and flatten action space to a single discrete action for Q learning
+print(wrapped.reset(seed=0))
+```
+
 ## POPGym Environments
 
 POPGym contains Partially Observable Markov Decision Process (POMDP) environments following the [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) interface. POPGym environments have minimal dependencies and fast enough to solve on a laptop CPU in less than a day. We provide the following environments:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import popgym
 from popgym.wrappers import PreviousAction, Antialias, Flatten, DiscreteAction
 env = popgym.envs.position_only_cartpole.PositionOnlyCartPoleEasy()
 print(env.reset(seed=0))
-wrapped = DiscreteAction(Flatten(PreviousAction(env))) # Append prev action to obs and flatten action space to a single discrete action for Q learning
+wrapped = DiscreteAction(Flatten(PreviousAction(env))) # Append prev action to obs, flatten obs/action spaces, then map the multidiscrete action space to a single discrete action for Q learning
 print(wrapped.reset(seed=0))
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ pip install "popgym[baselines]"
 ```
 
 ## Quickstart Usage
+
 ```python
 import popgym
 from popgym.wrappers import PreviousAction, Antialias, Flatten, DiscreteAction

--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ Please see the [documentation](https://popgym.readthedocs.io/en/latest/) for adv
 ## Quickstart Install
 
 ```python
-pip install popgym # base environments only, only requires numpy and gymnasium
-pip install --use-pep517 "popgym[navigation]" # also include navigation environments, which require mazelib
-pip install "popgym[baselines]" # environments and memory baselines
+# Install base environments, only requires numpy and gymnasium
+pip install popgym 
+# Also include navigation environments, which require mazelib
+# NOTE: navigation envs require python <3.12 due to mazelib not supporting 3.12
+pip install "popgym[navigation]" 
+# Install memory baselines w/ RLlib 
+pip install "popgym[baselines]" 
 ```
 
 ## POPGym Environments

--- a/popgym/envs/__init__.py
+++ b/popgym/envs/__init__.py
@@ -2,7 +2,7 @@
 """
 
 import inspect
-from importlib import find_loader
+from importlib.util import find_spec
 from typing import Any, Dict
 
 import gymnasium as gym
@@ -255,7 +255,7 @@ ALL_GAME = {**GAME_EASY, **GAME_MEDIUM, **GAME_HARD}
 #
 def has_mazelib():  # noqa: E302
     """Check if mazelib is installed"""
-    return find_loader("mazelib") is not None
+    return find_spec("mazelib") is not None
 
 
 if has_mazelib():

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ description = A collection of partially-observable procedural gym environments
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = Steven Morad
-version = 1.0.4
+version = 1.0.5
 license = MIT
 readme = README.md
 requires_python = >=3.7 


### PR DESCRIPTION
python3.12 removes `find_loader`, so replace it so popgym works with python3.12. Also bump flake8 version as old version has broken dependencies.