### PR TITLE
Fixed time step limit of Minesweeper environments

### DIFF
--- a/popgym/envs/minesweeper.py
+++ b/popgym/envs/minesweeper.py
@@ -81,11 +81,11 @@ class MineSweeper(POPGymEnv):
             self.hidden_grid[action] = HiddenSquare.VIEWED
             reward = self.success_reward_scale
 
-        truncated = self.timestep == self.max_episode_length
+        self.timestep += 1
         terminated |= np.all(self.hidden_grid != HiddenSquare.CLEAR).item()
+        truncated = (self.timestep == self.max_episode_length) and not terminated
 
         obs = self.neighbor_grid[action].item()
-        self.timestep += 1
 
         return obs, reward, terminated, truncated, {}
 


### PR DESCRIPTION
I noticed a bug in the Minesweeper environments. Essentially, the timestep is only incremented after the comparison with `max_episode_length`, which means that the environment always allows one step too many (meaning that the agent always has to make an illegal move in the end or select a mine). This PR fixes that bug.