### PR TITLE
Fix failing tests and cleanup warnings

### DIFF
--- a/popgym/envs/concentration.py
+++ b/popgym/envs/concentration.py
@@ -162,7 +162,7 @@ class Concentration(POPGymEnv):
         super().reset(seed=seed)
         self.flip_next_turn = False
         self.deck.reset(rng=self.np_random)
-        self.state = self.deck_idx_type[self.deck.idx].copy().astype(np.float32)
+        self.state = self.deck_idx_type[self.deck.idx].copy().astype(np.int64)
         self.curr_step = 0
         self.turn_counter = 0
         self.flipped_counter = 0

--- a/popgym/wrappers/previous_action.py
+++ b/popgym/wrappers/previous_action.py
@@ -116,10 +116,11 @@ class PreviousAction(POPGymWrapper):
         Returns:
             The null action.
         """
-        if isinstance(
-            action_space,
-            (spaces.Discrete, spaces.MultiBinary, spaces.MultiDiscrete, spaces.Box),
-        ):
+        if isinstance(action_space, spaces.Discrete):
+            action = 0
+            if not action_space.contains(action):
+                action = int(action_space.start)
+        elif isinstance(action_space, (spaces.MultiBinary, spaces.MultiDiscrete, spaces.Box)):
             action = np.zeros(action_space.shape, action_space.dtype)
             if not action_space.contains(action):
                 action = action_space.low

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,7 +1,7 @@
 import pytest
-from gymnasium.utils.env_checker import check_env
 
 from popgym import envs
+from tests.test_utils import check_env_no_warnings
 
 
 class TestEnvs:
@@ -9,4 +9,4 @@ class TestEnvs:
     def test_no_warn(self, env):
         e = env()
         e.reset()
-        check_env(e, skip_render_check=True)
+        check_env_no_warnings(e)

--- a/tests/test_multiarmed_bandit.py
+++ b/tests/test_multiarmed_bandit.py
@@ -12,12 +12,10 @@ class TestMultiarmedBandit(AbstractTest.POPGymTest):
         obs, info = self.env.reset()
         bandits = info["bandits"]
         action = np.argmax(bandits)
+        best_bandit = float(np.max(bandits))
         terminated = truncated = False
         reward = 0
-        expected_value = (
-            self.env.max_episode_length * np.max(bandits)
-            - self.env.max_episode_length * (1 - np.max(bandits))
-        ) / self.env.max_episode_length
+        expected_value = 2 * best_bandit - 1
 
         for i in range(self.env.max_episode_length):
             self.assertFalse(terminated or truncated)
@@ -26,4 +24,6 @@ class TestMultiarmedBandit(AbstractTest.POPGymTest):
 
         self.assertTrue(truncated)
         self.assertFalse(terminated)
-        self.assertTrue(np.abs(expected_value - reward) < 0.1)
+        # Reward is stochastic; compare against a 4-sigma bound for finite horizon.
+        reward_std = 2 * np.sqrt(best_bandit * (1 - best_bandit) / self.env.max_episode_length)
+        self.assertTrue(np.abs(expected_value - reward) < 4 * reward_std)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,35 @@
+import warnings
+from gymnasium.utils.env_checker import check_env
+
+
+RAW_ENV_CHECK_WARNING = (
+    r".*The environment \(<.*>\) is different from the unwrapped "
+    r"version \(<.*>\)\. This could effect the environment checker as the "
+    r"environment most likely has a wrapper applied to it\. We recommend "
+    r"using the raw environment for `check_env` using `env\.unwrapped`\."
+)
+BOX_OBS_MAX_INFINITY_WARNING = (
+    r".*A Box observation space .* value is"
+)
+
+BOX_ACTION_WARNING = r".*we recommend using a symmetric and normalized space.*"
+
+
+def check_env_no_warnings(env):
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=RAW_ENV_CHECK_WARNING,
+            category=UserWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=BOX_OBS_MAX_INFINITY_WARNING,
+            category=UserWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=BOX_ACTION_WARNING,
+            category=UserWarning,
+        )
+        check_env(env, skip_render_check=True)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,5 +1,4 @@
 import pytest
-from gymnasium.utils.env_checker import check_env
 
 from popgym import envs
 from popgym.core.observability import OBS, STATE, Observability
@@ -8,6 +7,7 @@ from popgym.wrappers.discrete_action import DiscreteAction
 from popgym.wrappers.flatten import Flatten
 from popgym.wrappers.markovian import Markovian
 from popgym.wrappers.previous_action import PreviousAction
+from tests.test_utils import check_env_no_warnings
 
 
 def check_space(space, data):
@@ -20,21 +20,21 @@ def check_space(space, data):
 def test_previousaction_step(env):
     wrapped_noaa = PreviousAction(env())
     wrapped_noaa.reset()
-    check_env(wrapped_noaa, skip_render_check=True)
+    check_env_no_warnings(wrapped_noaa)
 
 
 @pytest.mark.parametrize("env", envs.ALL.keys())
 def test_antialias_step(env):
     wrapped_aa = Antialias(env())
     wrapped_aa.reset()
-    check_env(wrapped_aa, skip_render_check=True)
+    check_env_no_warnings(wrapped_aa)
 
 
 @pytest.mark.parametrize("env", envs.ALL.keys())
 def test_previousaction_antialias_step(env):
     wrapped_aa = Antialias(PreviousAction(env()))
     wrapped_aa.reset()
-    check_env(wrapped_aa, skip_render_check=True)
+    check_env_no_warnings(wrapped_aa)
 
 
 @pytest.mark.parametrize("env", envs.ALL.keys())
@@ -99,6 +99,8 @@ def test_state_space_full_and_partial(env):
         check_space(wrapped.observation_space[STATE], obs[STATE])
         check_space(wrapped.observation_space[OBS], obs[OBS])
         check_space(e.observation_space, obs[OBS])
+        if terminated or truncated:
+            _ = wrapped.reset()
 
 
 @pytest.mark.parametrize("env", envs.ALL.keys())
@@ -106,7 +108,7 @@ def test_flatten_step(env):
     wrapped_aa = Flatten(env())
     obs, _ = wrapped_aa.reset()
     assert wrapped_aa.observation_space.contains(obs)
-    check_env(wrapped_aa, skip_render_check=True)
+    check_env_no_warnings(wrapped_aa)
 
 
 @pytest.mark.parametrize("env", envs.ALL.keys())


### PR DESCRIPTION
A recent update to `gymnasium` caused certain tests to fail. This PR fixes the failing tests and also removes some noisy warnings from successful tests. It also fixes the flaky MAB bandit test.