### PR TITLE
Fix count recall off-by-one action space

### DIFF
--- a/popgym/envs/count_recall.py
+++ b/popgym/envs/count_recall.py
@@ -72,7 +72,7 @@ class CountRecall(POPGymEnv):
         )
         self.last_obs = np.array([0, 0])
 
-        self.action_space = gym.spaces.Discrete(self.max_card_count)
+        self.action_space = gym.spaces.Discrete(self.max_card_count + 1)
         self.max_episode_length = self.value_deck.num_cards - 1
         self.error_clamp = error_clamp
         self.reward_scale = 1 / self.max_episode_length

--- a/tests/test_count_recall.py
+++ b/tests/test_count_recall.py
@@ -38,7 +38,7 @@ class TestCountRecall(AbstractTest.POPGymTest):
         obs, info = self.env.reset()
         d, q = obs
         counts[d] += 1
-        action = np.array([counts[q] + 2])
+        action = np.array(counts[q] + 2)
         reward = 0
         terminated = truncated = False
 
@@ -47,7 +47,7 @@ class TestCountRecall(AbstractTest.POPGymTest):
             obs, rew, terminated, truncated, info = self.env.step(action)
             d, q = obs
             counts[d] += 1
-            action = np.array([counts[q] + 2])
+            action = np.array(counts[q] + 2)
             reward += rew
             t += 1
 

--- a/tests/test_count_recall.py
+++ b/tests/test_count_recall.py
@@ -23,8 +23,9 @@ class TestCountRecall(AbstractTest.POPGymTest):
             obs, rew, terminated, truncated, info = self.env.step(action)
             d, q = obs
             counts[d] += 1
-            action = np.array([counts[q]])
+            action = np.array(counts[q])
             self.assertEqual(rew, 1 / (self.env.value_deck.num_cards - 1))
+            self.assertTrue(self.env.action_space.contains(action))
             reward += rew
             t += 1
 


### PR DESCRIPTION
This fixes the bug raised in https://github.com/proroklab/popgym/issues/40 and modifies the test to ensure that optimal actions are always within the action space.